### PR TITLE
Cancellabe request

### DIFF
--- a/Shoplive_iOS_ParkJiHo/Application/SceneDelegate.swift
+++ b/Shoplive_iOS_ParkJiHo/Application/SceneDelegate.swift
@@ -20,10 +20,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private func configureTabBar(with windowScene: UIWindowScene) {
         
         let marvelHeroFavoriteUseCase = MarvelHeroFavoriteUseCase(marvelHeroFavoriteRepository: MarvelHeroFavoriteRepository())
+        
         let heroSearchViewController = MarvelHeroSearchViewController()
+        let marvelHeroSearchUseCase = MarvelHeroSearchUseCase(marvelHeroSearchRepository: MarvelHeroSearchRepository())
         let heroSearchViewReactor = MarvelHeroSearchViewReactor(
-            marvelHeroSearchUseCase: MarvelHeroSearchUseCase(marvelHeroSearchRepository: MarvelHeroSearchRepository()),
-            marvelHeroFavoriteUseCase: marvelHeroFavoriteUseCase)
+            marvelHeroSearchUseCase: marvelHeroSearchUseCase,
+            marvelHeroFavoriteUseCase: marvelHeroFavoriteUseCase
+        )
         heroSearchViewController.reactor = heroSearchViewReactor
         let searchImage = UIImage(systemName: "magnifyingglass")
         let searchTabBarItem = UITabBarItem(title: "SEARCH", image: searchImage, selectedImage: nil)

--- a/Shoplive_iOS_ParkJiHo/Data/Local/FavoriteHeroDatabaseManager.swift
+++ b/Shoplive_iOS_ParkJiHo/Data/Local/FavoriteHeroDatabaseManager.swift
@@ -165,13 +165,15 @@ extension FavoriteHeroDatabaseManager {
                             name: String,
                             description: String,
                             thumbnailPath: String) throws -> FavoriteHero {
+        
+        var statement: OpaquePointer? = nil
         lock.lock()
         defer {
             lock.unlock()
+            sqlite3_finalize(statement)
         }
         
         let insertQuery = "INSERT INTO \(tableName) (id, hero_id, name, description, thumbnail_path) VALUES (?, ?, ?, ?, ?);"
-        var statement: OpaquePointer? = nil
         
         if sqlite3_prepare_v2(self.db, insertQuery, -1, &statement, nil) == SQLITE_OK {
             sqlite3_bind_int(statement, 2, Int32(heroID))

--- a/Shoplive_iOS_ParkJiHo/Data/Network/Repositories/MarvelHeroSearchRepository.swift
+++ b/Shoplive_iOS_ParkJiHo/Data/Network/Repositories/MarvelHeroSearchRepository.swift
@@ -13,10 +13,13 @@ import RxSwift
 final class MarvelHeroSearchRepository: MarvelHeroSearchRepositoryType {
     
     let provider = MoyaProvider<MarvelHeroSearchAPI>()
-    
+    var cancellable: Cancellable?
+
     func search(name: String, offset: Int) -> Single<HeroSearch> {
         let request = HeroSearchRequestDTO(nameStartsWith: name, offset: offset)
-        return provider.request(.search(request), responseDataType: HeroSearchDTO.self)
-            .map { $0.toDomain() }
+        return provider.request(.search(request), responseDataType: HeroSearchDTO.self, completion: { [weak self] cancellable in
+            self?.cancellable = cancellable
+        })
+        .map { $0.toDomain() }
     }
 }

--- a/Shoplive_iOS_ParkJiHo/Domain/Interfaces/MarvelHeroSearchRepositoryType.swift
+++ b/Shoplive_iOS_ParkJiHo/Domain/Interfaces/MarvelHeroSearchRepositoryType.swift
@@ -5,8 +5,10 @@
 //  Created by jiho park on 5/21/24.
 //
 
+import Moya
 import RxSwift
 
 protocol MarvelHeroSearchRepositoryType {
+    var cancellable: Cancellable? { get }
     func search(name: String, offset: Int) -> Single<HeroSearch>
 }

--- a/Shoplive_iOS_ParkJiHo/Domain/UseCases/MarvelHeroSearchUseCase.swift
+++ b/Shoplive_iOS_ParkJiHo/Domain/UseCases/MarvelHeroSearchUseCase.swift
@@ -5,16 +5,21 @@
 //  Created by jiho park on 5/21/24.
 //
 
+import Moya
 import RxSwift
 
 protocol MarvelHeroSearchUseCaseType {
+    var cancellable: Cancellable? { get }
     func search(name: String, offset: Int) -> Single<HeroSearch>
 }
 
 final class MarvelHeroSearchUseCase: MarvelHeroSearchUseCaseType {
 
     private let marvelHeroSearchRepository: MarvelHeroSearchRepositoryType
-    
+    var cancellable: Cancellable? {
+        marvelHeroSearchRepository.cancellable
+    }
+
     init(marvelHeroSearchRepository: MarvelHeroSearchRepositoryType) {
         self.marvelHeroSearchRepository = marvelHeroSearchRepository
     }

--- a/Shoplive_iOS_ParkJiHo/Extension/Moya+Extension.swift
+++ b/Shoplive_iOS_ParkJiHo/Extension/Moya+Extension.swift
@@ -11,9 +11,9 @@ import Moya
 import RxSwift
 
 extension MoyaProvider {
-    func request<T: Decodable>(_ target: Target, responseDataType: T.Type) -> Single<T> {
+    func request<T: Decodable>(_ target: Target, responseDataType: T.Type, completion: ((Cancellable) -> Void)? = nil) -> Single<T> {
         return Single.create { single in
-            self.request(target) { result in
+            let cancellable = self.request(target) { result in
                 do {
                     switch result {
                     case let .success(response):
@@ -36,6 +36,7 @@ extension MoyaProvider {
                     single(.failure(NetworkError.unknwon))
                 }
             }
+            completion?(cancellable)
             return Disposables.create()
         }
     }

--- a/Shoplive_iOS_ParkJiHo/Extension/UIViewController+Extension.swift
+++ b/Shoplive_iOS_ParkJiHo/Extension/UIViewController+Extension.swift
@@ -30,6 +30,7 @@ extension UIViewController {
         if let error = error as? NetworkError {
             self.presentAlert(message: error.localizedDescription, confirmTitle: "확인")
         } else if let error = error as? MoyaError {
+            guard let afError = error.asAFError, !afError.isExplicitlyCancelledError else { return }
             self.presentAlert(message: error.localizedDescription, confirmTitle: "확인")
         } else if let error = error as? DatabaseError {
             self.presentAlert(message: error.localizedDescription, confirmTitle: "확인")

--- a/Shoplive_iOS_ParkJiHo/Presentation/Cell/MarvelHeroCell.swift
+++ b/Shoplive_iOS_ParkJiHo/Presentation/Cell/MarvelHeroCell.swift
@@ -48,6 +48,7 @@ final class MarvelHeroCell: UICollectionViewCell, View {
         
         addSubview()
         setUpconstraints()
+        setUpView()
     }
     
     required init?(coder: NSCoder) {
@@ -76,6 +77,10 @@ final class MarvelHeroCell: UICollectionViewCell, View {
             make.top.equalTo(nameLabel.snp.bottom).offset(20)
             make.leading.bottom.trailing.equalToSuperview()
         }
+    }
+    
+    private func setUpView() {
+        self.contentView.backgroundColor = .systemBackground
     }
     
     func bind(reactor: MarvelHeroCellReactor) {
@@ -109,7 +114,7 @@ final class MarvelHeroCell: UICollectionViewCell, View {
             .distinctUntilChanged()
             .asDriver(onErrorDriveWith: .empty())
             .drive(onNext: { [weak self] isFavorite in
-                self?.contentView.backgroundColor = isFavorite ? .gray : .white
+                self?.contentView.backgroundColor = isFavorite ? .gray : .systemBackground
             })
             .disposed(by: disposeBag)
     }

--- a/Shoplive_iOS_ParkJiHo/Presentation/HeroSearchView/MarvelHeroSearchViewReactor.swift
+++ b/Shoplive_iOS_ParkJiHo/Presentation/HeroSearchView/MarvelHeroSearchViewReactor.swift
@@ -159,7 +159,8 @@ final class MarvelHeroSearchViewReactor: Reactor {
 
 extension MarvelHeroSearchViewReactor {
     private func searchMarvelHero(name: String, offset: Int) -> Observable<Mutation> {
-        marvelHeroSearchUseCase.search(name: name, offset: offset)
+        marvelHeroSearchUseCase.cancellable?.cancel()
+        return marvelHeroSearchUseCase.search(name: name, offset: offset)
             .asObservable()
             .flatMap { response -> Observable<Mutation> in
                 let heroSearchViewModel = HeroSearchViewModel(with: response)

--- a/Shoplive_iOS_ParkJiHoTests/Mocks/MarvelHeroSearchRepositoryMock.swift
+++ b/Shoplive_iOS_ParkJiHoTests/Mocks/MarvelHeroSearchRepositoryMock.swift
@@ -9,8 +9,10 @@
 import Foundation
 
 import RxSwift
+import Moya
 
 final class MarvelHeroSearchRepositoryMock: MarvelHeroSearchRepositoryType {
+    var cancellable: Cancellable?
     var shouldSucceed: Bool = true
     func search(name: String, offset: Int) -> Single<HeroSearch> {
         return Single.create { [unowned self] single in


### PR DESCRIPTION
## 개요
- 마블 영웅 검색 API 호출 시 이전 API 호출을 취소하도록 구현합니다.

## 작업 내용
- MoyaProvider를 이용한 request시 반환되는 cancellable의 cancel()을 호출하도록 해서 이전 API 호출을 취소하도록 하였습니다.
- 로컬 데이터베이스에 좋아요 영웅 삽입 후 prepared statement를 제거해서 메모리 누수를 방지하기 위해 sqlite3_finalize를 호출하도록 수정하였습니다.