### PR TITLE
fixWrongNextPageRequest

### DIFF
--- a/Shoplive_iOS_ParkJiHo/Extension/UIScrollView+Extension.swift
+++ b/Shoplive_iOS_ParkJiHo/Extension/UIScrollView+Extension.swift
@@ -15,8 +15,7 @@ extension Reactive where Base: UIScrollView {
         let observable = contentOffset
             .filter { [weak base] contentOffset in
                 guard let scrollView = base,
-                      scrollView.contentOffset.y > 0
-                else { return false }
+                      scrollView.contentOffset.y > 0 else { return false }
                 
                 return contentOffset.y + scrollView.frame.height > scrollView.contentSize.height * portion
             }

--- a/Shoplive_iOS_ParkJiHo/Presentation/HeroSearchView/MarvelHeroSearchViewReactor.swift
+++ b/Shoplive_iOS_ParkJiHo/Presentation/HeroSearchView/MarvelHeroSearchViewReactor.swift
@@ -78,10 +78,9 @@ final class MarvelHeroSearchViewReactor: Reactor {
         case .loadNextPage:
             guard currentState.hasNextPage,
                   currentState.isLoading == false,
-                  let searchTerm = currentState.searchTerm
-            else {
-                return .empty()
-            }
+                  let searchTerm = currentState.searchTerm,
+                  searchTerm.count >= 2 else { return .empty() }
+            
             return .concat(.just(.setLoading(true)),
                            searchMarvelHero(name: searchTerm, offset: currentState.currentHeroCount),
                            .just(.setLoading(false))


### PR DESCRIPTION
## 개요
-  검색 결과 컬렉션뷰의 contentOffset이 1 이상일때 검색어 전체 삭제 시 다음 페이지를 로드하는 오류를 수정합니다.

## 작업 내용
- 검색어가 2글자 이상일 때 다음 페이지를 로드하도록 수정하였습니다.